### PR TITLE
Improve TimeLord v2 settings

### DIFF
--- a/apps/timelord-v2/index.html
+++ b/apps/timelord-v2/index.html
@@ -8,7 +8,8 @@
 </head>
 <body>
   <h1 id="prompt"><span id="promptPrefix"></span> <span id="targetTime"></span> Uhr!</h1>
-  <div id="controls">
+  <button id="settingsBtn" aria-label="Einstellungen">⚙</button>
+  <div id="settingsBox">
     <label id="langLabel" for="langSelect">Sprache</label>
     <select id="langSelect">
       <option value="de">DE</option>

--- a/apps/timelord-v2/main.css
+++ b/apps/timelord-v2/main.css
@@ -11,11 +11,27 @@ h1 {
   font-size: 6vmin;
 }
 
-#controls {
+#settingsBtn {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
-  display: flex;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: none;
+  font-size: 5vmin;
+  background: #ffffffcc;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  z-index: 11;
+}
+
+#settingsBox {
+  position: fixed;
+  bottom: 4.5rem;
+  right: 1rem;
+  display: none;
   flex-direction: column;
   align-items: flex-end;
   gap: 0.5rem;
@@ -25,6 +41,10 @@ h1 {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
   z-index: 10;
+}
+
+#settingsBox.show {
+  display: flex;
 }
 
 label {

--- a/apps/timelord-v2/main.js
+++ b/apps/timelord-v2/main.js
@@ -9,6 +9,8 @@ const LANG_SELECT = document.getElementById('langSelect');
 const DIFFICULTY_SELECT = document.getElementById('difficultySelect');
 const CONTRAST_BTN = document.getElementById('contrastBtn');
 const AUDIO_ENABLED = document.getElementById('soundToggle');
+const SETTINGS_BTN = document.getElementById('settingsBtn');
+const SETTINGS_BOX = document.getElementById('settingsBox');
 
 let currentOptions = [];
 let currentTarget = null;
@@ -205,6 +207,10 @@ LANG_SELECT.addEventListener('change', () => {
 
 CONTRAST_BTN.addEventListener('click', () => {
   document.body.classList.toggle('high-contrast');
+});
+
+SETTINGS_BTN.addEventListener('click', () => {
+  SETTINGS_BOX.classList.toggle('show');
 });
 
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- add a settings button
- group language, difficulty and sound options in a settings panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846d2d0a688832eaf194a78e38f9a33